### PR TITLE
Ajoute la config dependabot pour la mise à jour des dépendances Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/api/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
cf. https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates